### PR TITLE
feat: export installments to xls

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -114,6 +114,12 @@
     </table>
   </div>
 
+  <div class="container-button" *ngIf="installments.length">
+    <button mat-raised-button (click)="downloadXls()">
+      Download XLS
+    </button>
+  </div>
+
   <br />
   <br />
   <br />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -159,6 +159,42 @@ export class AppComponent {
     });
   }
 
+  downloadXls() {
+    const headers = [
+      '#',
+      'Amortization',
+      'Interest',
+      'Pending amount',
+      'Installment',
+    ];
+
+    let table = '<table><tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr>';
+
+    this.installments.forEach((i) => {
+      table +=
+        '<tr>' +
+        [
+          i.numberInstallment,
+          i.amortization,
+          i.interest,
+          i.pendingAmount,
+          i.installment,
+        ]
+          .map((v) => `<td>${v}</td>`)
+          .join('') +
+        '</tr>';
+    });
+
+    table += '</table>';
+
+    const blob = new Blob([table], { type: 'application/vnd.ms-excel' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'installments.xls';
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }
+
   getErrorMessage(controlName: string) {
     const control = this.form.get(controlName);
 


### PR DESCRIPTION
## Summary
- add a button to export calculated installments to an XLS file

## Testing
- `npm test -- --watch=false` *(fails: error TS18003: No inputs were found in config file)*
- `npm run build` *(fails: Inlining of fonts failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bee7239734833198745f55fb9cfb0f